### PR TITLE
fix: properly use accessor to get input values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ go.work
 debug.log
 
 *.iml
+.idea

--- a/field_input.go
+++ b/field_input.go
@@ -351,14 +351,14 @@ func (i *Input) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch {
 		case key.Matches(msg, i.keymap.Prev):
-			value := i.textinput.Value()
+			value := i.accessor.Get()
 			i.err = i.validate(value)
 			if i.err != nil {
 				return i, nil
 			}
 			cmds = append(cmds, PrevField)
 		case key.Matches(msg, i.keymap.Next, i.keymap.Submit):
-			value := i.textinput.Value()
+			value := i.accessor.Get()
 			i.err = i.validate(value)
 			if i.err != nil {
 				return i, nil


### PR DESCRIPTION
This is a bug that prevents us from using accessors to control form input (namely to automatically trim spaces)